### PR TITLE
Add Tap It game UI and routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ const Games = lazy(() => import('./pages/static/Games'));
 const PokerNumber = lazy(() => import('./pages/static/PokerNumber'));
 const Tambola = lazy(() => import('./pages/static/Tambola'));
 const TapIt = lazy(() => import('./pages/static/TapIt'));
+const TapItGame = lazy(() => import('./pages/tapit/Game'));
 const TugOfWar = lazy(() => import('./pages/static/TugOfWar'));
 
 // Minimal loading component
@@ -28,6 +29,7 @@ const App: React.FC = () => {
               <Route path="/poker-number" element={<PokerNumber />} />
               <Route path="/tambola" element={<Tambola />} />
               <Route path="/tap-it" element={<TapIt />} />
+              <Route path="/tap-it/game/:roomName" element={<TapItGame />} />
               <Route path="/tug-of-war" element={<TugOfWar />} />
             </Routes>
           </Suspense>

--- a/src/components/tapit/CountdownCircle.tsx
+++ b/src/components/tapit/CountdownCircle.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+interface CountdownCircleProps {
+    duration: number;
+    timeLeft: number;
+}
+
+const CountdownCircle: React.FC<CountdownCircleProps> = ({ duration, timeLeft }) => {
+    const radius = 45;
+    const circumference = 2 * Math.PI * radius;
+    const progress = timeLeft / duration;
+    const offset = circumference * (1 - progress);
+
+    let strokeColor = 'var(--bs-success)';
+    if (timeLeft <= 5) {
+        strokeColor = 'var(--bs-danger)';
+    } else if (timeLeft <= 10) {
+        strokeColor = 'var(--bs-orange)';
+    }
+
+    return (
+        <svg width="100" height="100" viewBox="0 0 100 100" className="d-block">
+            <circle
+                cx="50"
+                cy="50"
+                r={radius}
+                stroke="var(--bs-gray-300)"
+                strokeWidth="10"
+                fill="transparent"
+            />
+            <circle
+                cx="50"
+                cy="50"
+                r={radius}
+                stroke={strokeColor}
+                strokeWidth="10"
+                fill="transparent"
+                strokeDasharray={circumference}
+                strokeDashoffset={offset}
+                strokeLinecap="round"
+                style={{ transition: 'stroke 0.3s, stroke-dashoffset 1s linear', transform: 'rotate(-90deg)', transformOrigin: '50% 50%' }}
+            />
+            <text
+                x="50"
+                y="55"
+                textAnchor="middle"
+                className="fw-bold"
+                fontSize="24"
+                fill="var(--bs-dark)"
+            >
+                {timeLeft}
+            </text>
+        </svg>
+    );
+};
+
+export default CountdownCircle;

--- a/src/pages/static/TapIt.tsx
+++ b/src/pages/static/TapIt.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import GameLayout from '../../components/GameLayout';
 
 const TapIt: React.FC = () => {
     const [roomName, setRoomName] = useState('');
+    const navigate = useNavigate();
 
     const handleEnterRoom = () => {
         if (roomName.trim()) {
-            // TODO: Implement room joining logic
-            // eslint-disable-next-line no-console
-            console.log('Entering room:', roomName);
+            navigate(`/tap-it/game/${encodeURIComponent(roomName)}`);
         }
     };
 

--- a/src/pages/tapit/Game.tsx
+++ b/src/pages/tapit/Game.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
+import CountdownCircle from '../../components/tapit/CountdownCircle';
+
+const GAME_DURATION = 30;
+
+const TapItGame: React.FC = () => {
+    const { roomName } = useParams();
+    const [count, setCount] = useState(0);
+    const [timeLeft, setTimeLeft] = useState(GAME_DURATION);
+    const timerRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        timerRef.current = window.setInterval(() => {
+            setTimeLeft((prev) => {
+                if (prev <= 1) {
+                    if (timerRef.current !== null) {
+                        window.clearInterval(timerRef.current);
+                    }
+                    return 0;
+                }
+                return prev - 1;
+            });
+        }, 1000);
+        return () => {
+            if (timerRef.current !== null) {
+                window.clearInterval(timerRef.current);
+            }
+        };
+    }, []);
+
+    const handleTap = () => {
+        if (timeLeft > 0) {
+            setCount((c) => c + 1);
+        }
+    };
+
+    return (
+        <div className="d-flex flex-column min-vh-100 bg-white" onPointerDown={handleTap} role="button">
+            <Helmet>
+                <title>Tap It – Room {roomName} | Bazonka</title>
+            </Helmet>
+            <div className="d-flex justify-content-center p-3">
+                <CountdownCircle duration={GAME_DURATION} timeLeft={timeLeft} />
+            </div>
+            <div className="flex-grow-1 d-flex align-items-center justify-content-center">
+                <span className="display-1 fw-bold user-select-none">{count}</span>
+            </div>
+        </div>
+    );
+};
+
+export default TapItGame;


### PR DESCRIPTION
## Summary
- add dedicated Tap It game route and lazy loaded component
- connect Tap It rules page to game room navigation
- implement tap counter with animated color-changing circular timer

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac976bc8488323938599da93760729